### PR TITLE
Add ZINC_SERVER_ADDRESS to documentation

### DIFF
--- a/docs/Zinc/environment-variables.md
+++ b/docs/Zinc/environment-variables.md
@@ -6,6 +6,7 @@ We prefer environment variables for configuration as opposed to configuration fi
 | ----------------------------- | ------------- |-------------- | ------------------------------------------------------------------------- |
 | ZINC_FIRST_ADMIN_USER         | -             | On first run  | First admin user of ZincSearch. Not required after first run of ZincSearch.  |
 | ZINC_FIRST_ADMIN_PASSWORD     | -             | On first run  | Password for first admin user                                             |
+| ZINC_SERVER_ADDRESS           | 0.0.0.0       | No            | zinc server IP address to bind to                                         |
 | ZINC_SERVER_PORT              | 4080          | No            | zinc server listen http port                                              |
 | GIN_MODE                      | -             | No            | if the value is release then gin will run in production mode.             |
 | ZINC_DATA_PATH                | ./data        | No            | Defaults to "data" folder in current working directory if not provided.   |


### PR DESCRIPTION
Set the `ZINC_SERVER_ADDRESS` environment variable to the server IP bind address.